### PR TITLE
URL encode data used in StringBooleanCondition.

### DIFF
--- a/AmazingCloudSearch.Test/Query/StringBooleanConditionTester.cs
+++ b/AmazingCloudSearch.Test/Query/StringBooleanConditionTester.cs
@@ -28,6 +28,14 @@ namespace AmazingCloudSearch.Test.Query
         }
 
         [Test]
+        public void ShouldUrlEscapeTheValue()
+        {            
+            var stringBooleanCondition = new StringBooleanCondition(Field, " & ");
+            var output = stringBooleanCondition.GetConditionParam();
+            output.ShouldEndWith(string.Format("'%20%26%20'"));
+        }
+
+        [Test]
         public void ShouldEncloseTheConditionInQuotes()
         {            
             var stringBooleanCondition = new StringBooleanCondition(Field, Condition);

--- a/AmazingCloudSearch/Query/Boolean/StringBooleanCondition.cs
+++ b/AmazingCloudSearch/Query/Boolean/StringBooleanCondition.cs
@@ -1,4 +1,5 @@
-﻿using AmazingCloudSearch.Enum;
+﻿using System;
+using AmazingCloudSearch.Enum;
 namespace AmazingCloudSearch.Query.Boolean
 {
     public class StringBooleanCondition : IBooleanCondition
@@ -16,7 +17,7 @@ namespace AmazingCloudSearch.Query.Boolean
 
         public string GetConditionParam()
         {
-            var output = "'" + Condition + "'";
+            var output = "'" + Uri.EscapeDataString(Condition) + "'";
 
             if (!string.IsNullOrWhiteSpace(Field))
                 output = Field + "%3A" +  output;


### PR DESCRIPTION
Heya, this one came up when we tried to query with things like & in the condition. Is this the correct place to be encoding this data?
